### PR TITLE
Aplayer歌曲列表滑动出现

### DIFF
--- a/js/sakura-app.js
+++ b/js/sakura-app.js
@@ -782,15 +782,24 @@ if(mashiro_option.float_player_on) {
                         lrcTag = 2;
                     });
                     var apSwitchTag = 0;
+                    var aplayerlist=$(".aplayer-list");
+                    aplayerlist.removeClass( "aplayer-list-hide" );
+                    aplayerlist.css({maxHeight:'0px'});
                     $(".aplayer.aplayer-fixed .aplayer-body").addClass("ap-hover");
                     $(".aplayer-miniswitcher").click(function(){
                         if (apSwitchTag == 0) {
+                            aplayerlist.removeClass( "aplayer-list-hide" );
+                            aplayerlist.animate({maxHeight:'250px'});
                             $(".aplayer.aplayer-fixed .aplayer-body").removeClass( "ap-hover" );
                             apSwitchTag = 1;
                         } else {
+                            aplayerlist.css({maxHeight:'0px'});
                             $(".aplayer.aplayer-fixed .aplayer-body").addClass( "ap-hover" );
                             apSwitchTag =0;
                         }
+                    });
+                    $(".aplayer-icon-loop").click(function(){
+
                     });
                 }
                 var b = 'https://api.i-meto.com/meting/api?server=:server&type=:type&id=:id&r=:r';

--- a/js/sakura-app.js
+++ b/js/sakura-app.js
@@ -798,9 +798,6 @@ if(mashiro_option.float_player_on) {
                             apSwitchTag =0;
                         }
                     });
-                    $(".aplayer-icon-loop").click(function(){
-
-                    });
                 }
                 var b = 'https://api.i-meto.com/meting/api?server=:server&type=:type&id=:id&r=:r';
                 'undefined' != typeof meting_api && (b = meting_api);


### PR DESCRIPTION
当Aplayer的侧边 ‘>’按钮被点击后，Aplayer整体滑出，然后歌曲列表缓慢滑出。比起直接出现，观感应该会好一些。

非常抱歉在 801-803加了些无用代码，可以删除。
