### PR TITLE
修复由切换qq头像和gravatar头像导致的报错问题

### DIFF
--- a/js/sakura-app.js
+++ b/js/sakura-app.js
@@ -864,53 +864,56 @@ function getqqinfo() {
     }
     var emailAddressFlag = cached.filter('#email').val();
     cached.filter('#author').on('blur', function () {
-        var qq = cached.filter('#author').val();
-        $.ajax({
-            type: 'get',
-            url: mashiro_option.qq_api_url + '?qq=' + qq + '&_wpnonce=' + Poi.nonce,
-            dataType: 'json',
-            success: function (data) {
-                cached.filter('#author').val(data.name);
-                cached.filter('#email').val($.trim(qq) + '@qq.com');
-                if (mashiro_option.qzone_autocomplete) {
-                    cached.filter('#url').val('https://user.qzone.qq.com/' + $.trim(qq));
-                }
-                $('div.comment-user-avatar img').attr('src', 'https://q2.qlogo.cn/headimg_dl?dst_uin=' + qq + '&spec=100');
-                is_get_by_qq = true;
-                cached.filter('#qq').val($.trim(qq));
-                if (cached.filter('#qq').val()) {
-                    $('.qq-check').css('display', 'block');
-                    $('.gravatar-check').css('display', 'none');
-                }
-                setCookie('user_author', data.name, 30);
-                setCookie('user_qq', qq, 30);
-                setCookie('is_user_qq', 'yes', 30);
-                setCookie('user_qq_email', qq + '@qq.com', 30);
-                setCookie('user_email', qq + '@qq.com', 30);
-                emailAddressFlag = cached.filter('#email').val();
-                /***/
-                $('div.comment-user-avatar img').attr('src', data.avatar);
-                setCookie('user_avatar', data.avatar, 30);
-            },
-            error: function () {
-                cached.filter('#qq').val('');
-                $('.qq-check').css('display', 'none');
-                $('.gravatar-check').css('display', 'block');
-                $('div.comment-user-avatar img').attr('src', get_gravatar(cached.filter('#email').val(), 80));
-                setCookie('user_qq', '', 30);
-                setCookie('user_email', cached.filter('#email').val(), 30);
-                setCookie('user_avatar', get_gravatar(cached.filter('#email').val(), 80), 30);
-                /***/
-                cached.filter('#qq,#email,#url').val('');
-                if (!cached.filter('#qq').val()) {
+        var qq = cached.filter('#author').val(),
+            $reg = /^[1-9]\d{4,9}$/;
+        if ($reg.test(qq)) {
+            $.ajax({
+                type: 'get',
+                url: mashiro_option.qq_api_url + '?qq=' + qq + '&_wpnonce=' + Poi.nonce,
+                dataType: 'json',
+                success: function (data) {
+                    cached.filter('#author').val(data.name);
+                    cached.filter('#email').val($.trim(qq) + '@qq.com');
+                    if (mashiro_option.qzone_autocomplete) {
+                        cached.filter('#url').val('https://user.qzone.qq.com/' + $.trim(qq));
+                    }
+                    $('div.comment-user-avatar img').attr('src', 'https://q2.qlogo.cn/headimg_dl?dst_uin=' + qq + '&spec=100');
+                    is_get_by_qq = true;
+                    cached.filter('#qq').val($.trim(qq));
+                    if (cached.filter('#qq').val()) {
+                        $('.qq-check').css('display', 'block');
+                        $('.gravatar-check').css('display', 'none');
+                    }
+                    setCookie('user_author', data.name, 30);
+                    setCookie('user_qq', qq, 30);
+                    setCookie('is_user_qq', 'yes', 30);
+                    setCookie('user_qq_email', qq + '@qq.com', 30);
+                    setCookie('user_email', qq + '@qq.com', 30);
+                    emailAddressFlag = cached.filter('#email').val();
+                    /***/
+                    $('div.comment-user-avatar img').attr('src', data.avatar);
+                    setCookie('user_avatar', data.avatar, 30);
+                },
+                error: function () {
+                    cached.filter('#qq').val('');
                     $('.qq-check').css('display', 'none');
                     $('.gravatar-check').css('display', 'block');
-                    setCookie('user_qq', '', 30);
                     $('div.comment-user-avatar img').attr('src', get_gravatar(cached.filter('#email').val(), 80));
+                    setCookie('user_qq', '', 30);
+                    setCookie('user_email', cached.filter('#email').val(), 30);
                     setCookie('user_avatar', get_gravatar(cached.filter('#email').val(), 80), 30);
+                    /***/
+                    cached.filter('#qq,#email,#url').val('');
+                    if (!cached.filter('#qq').val()) {
+                        $('.qq-check').css('display', 'none');
+                        $('.gravatar-check').css('display', 'block');
+                        setCookie('user_qq', '', 30);
+                        $('div.comment-user-avatar img').attr('src', get_gravatar(cached.filter('#email').val(), 80));
+                        setCookie('user_avatar', get_gravatar(cached.filter('#email').val(), 80), 30);
+                    }
                 }
-            }
-        });
+            });
+        }
         // $.ajax({
         //     type: 'get',
         //     url: mashiro_option.qq_avatar_api_url + '?type=getqqavatar&qq=' + qq,


### PR DESCRIPTION
## 报错复现
在评论区填写完qq号并自动补全邮箱后，如果将光标在qq输入框和邮箱输入框来回切换会导致报错

错误可在[演示站](https://sakura.2heng.xin/)中复现

## 修复方式
通过使用正则验证qq的方式限制 qq api 的调用来修复

