### PR TITLE
fix: fix duplicate column, fix sending email

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1001,7 +1001,7 @@ function comment_mail_notify($comment_id)
                       margin: 10px auto 0; " target="_blank" href="' . htmlspecialchars(get_comment_link($parent_id)) . '">点击查看回复的完整內容</a>
       </div>
         <p style="font-size: 12px;text-align: center;color: #999;">本邮件为系统自动发出，请勿直接回复<br>
-        &copy; ' . date(Y) . ' ' . get_option("blogname") . '</p>
+        &copy; ' . date("Y") . ' ' . get_option("blogname") . '</p>
       </div>
     </div>
 ';
@@ -1809,7 +1809,7 @@ function markdown_parser($incoming_comment)
     }
     $myCustomer = $wpdb->get_row("SELECT * FROM wp_comments");
     //Add column if not present.
-    if (!isset($myCustomer->comment_markdown)) {
+    if (!property_exists($myCustomer, "comment_markdown")) {
         $wpdb->query("ALTER TABLE wp_comments ADD comment_markdown text");
     }
     $comment_markdown_content = $incoming_comment['comment_content'];


### PR DESCRIPTION
1. markdown解析的时候存在第一条评论`comment_markdown`列存在但为`NULL`的情况。`isset`会导致wp抛出一个`Duplicate column comment_markdown`的error。
![bug](https://user-images.githubusercontent.com/43714297/128617419-84b1b05e-ecda-4c80-87f5-747617776905.png)<br>
![image](https://user-images.githubusercontent.com/43714297/128617460-f45f8239-1ce2-4366-ac2d-2e4471c4436a.png)

2. 不太懂PHP，但是发送email `date`的格式化字符串如果没加双引号会导致我这边发送email通知失败。
环境信息：
> WordPress: 5.8
> PHP: 
> PHP 8.0.8 (cli) (built: Jun 29 2021 07:41:19) ( NTS gcc x86_64 )
Copyright (c) The PHP Group
Zend Engine v4.0.8, Copyright (c) Zend Technologies
    with Zend OPcache v8.0.8, Copyright (c), by Zend Technologies


![image](https://user-images.githubusercontent.com/43714297/128617494-dd87e477-3a37-4b23-93a5-c007c1c55c90.png)
