### PR TITLE
追番页面给每个图片单独设置 referrerPolicy

### DIFF
--- a/inc/classes/Bilibili.php
+++ b/inc/classes/Bilibili.php
@@ -50,7 +50,7 @@ class Bilibili
             }
             $html .= '<div class="column">
                 <a class="bangumi-item" href="https://bangumi.bilibili.com/anime/' . $list['season_id'] . '/" target="_blank" rel="nofollow">
-                    <img class="bangumi-image" src="' . str_replace('http://', 'https://', $list['cover']) . '"/>
+                    <img class="bangumi-image" referrerPolicy="no-referrer" src="' . str_replace('http://', 'https://', $list['cover']) . '"/>
                     <div class="bangumi-info">
                         <h3 class="bangumi-title" title="' . $list['title'] . '">' . $list['title'] . '</h2>
                         <div class="bangumi-summary"> ' . $list['evaluate'] . ' </div>

--- a/user/page-bangumi.php
+++ b/user/page-bangumi.php
@@ -3,9 +3,8 @@
 /**
  Template Name: Bangumi
  */
-get_header(); 
+get_header();
 ?>
-<meta name="referrer" content="same-origin">
 <style>
 #content,.comments,.site-footer{max-width:1200px;}
 .comments{display: none}
@@ -23,7 +22,7 @@ get_header();
                 <div class="row">
             <?php
                 $bgm = new \Sakura\API\Bilibili();
-                echo $bgm->get_bgm_items(); 
+                echo $bgm->get_bgm_items();
             ?>
             <?php else: ?>
                 <div class="row">


### PR DESCRIPTION
page-bangumi.php 中设置了全局 referrer 规则：非同源请求不发送 referer `<meta name="referrer" content="same-origin">`。
如果开启了 PJAX 局部刷新，从追番页面去到其它页面该规则也会被保留，这会导致后面的非同源请求也不发送 referer。
如果有非同源资源比如 CDN 禁止空 referer 请求，那么这部分资源就会无法访问。