### PR TITLE
Add Common CAPTCHA to Comments to Prevent Malicious Submissions, Update QQ Interface

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -3,6 +3,8 @@ Sakura🌸: A Wonderful WordPress Theme
 
 [中文](README.md) | English
 
+> This repository is forked from mashirozx/sakura and is in the process of integrating years of modifications made for gymxbl.com into the theme. It is primarily for personal use and compatibility with other sites is not guaranteed.
+
 ![Sakura](screenshot.jpg)
 
 ![PHP version](https://img.shields.io/badge/PHP-7.1+-4F5B93.svg?style=flat-square&logo=php)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 中文 | [English](README-en.md)
 
+> 这个仓库是从mashirozx/sakura派生出来的，正在将gymxbl.com多年来的修改整合到了主题中。这个仓库主要用于个人使用，不保证与其他网站的兼容性。
+
 ![Sakura](screenshot.jpg)
 
 ![PHP version](https://img.shields.io/badge/PHP-7.1+-4F5B93.svg?style=flat-square&logo=php)

--- a/comments.php
+++ b/comments.php
@@ -46,7 +46,14 @@
 				<?php endif; ?>
 
 			<?php endif; ?>
-
+                        <?php if (akina_option('verification_type') == 'Google reCAPTCHA'&& akina_option('rehidden') == '1') {?>
+			<!--添加隐形验证码-->
+			<div id="recaptcha" class="g-recaptcha"
+                             data-sitekey="<?php  echo akina_option('site_key'); ?>"
+                             data-callback="onRecaptchaSubmit"
+                             data-size="invisible">
+	                </div>
+			<?php }?>
 			<?php
 				$robot_comments = '';
 				if(comments_open()){

--- a/comments.php
+++ b/comments.php
@@ -50,7 +50,18 @@
 			<?php
 				$robot_comments = '';
 				if(comments_open()){
-					if(akina_option('norobot')) $robot_comments = '<label class="siren-checkbox-label"><input class="siren-checkbox-radio" type="checkbox" name="no-robot"><span class="siren-no-robot-checkbox siren-checkbox-radioInput"></span>'.__('I\'m not a robot', 'sakura').'</label>';
+					if(akina_option('norobot')) 
+					if (akina_option('verification_type') == 'CF Turnstile') {
+                                        $robot_comments = '<label class="siren-checkbox-label"> <div class="cf-turnstile" data-sitekey="'.akina_option('site_key').'"></div> </label>';
+                                        } elseif (akina_option('verification_type') == 'Google reCAPTCHA') {
+                                        $robot_comments = '<label class="siren-checkbox-label"><div class="g-recaptcha" data-sitekey="'.akina_option('site_key').'"></div></label>';
+                                        } elseif(akina_option('verification_type') == 'Google reCAPTCHA v3'){
+                                        $robot_comments = '<label class="siren-checkbox-label"><script>grecaptcha.ready(function() { grecaptcha.execute("'.akina_option('site_key').'", {action: "submit"}).then(function(token) { var form = document.getElementById("commentform"); var input = document.createElement("input"); input.setAttribute("type", "hidden"); input.setAttribute("name", "g-recaptcha-response"); input.setAttribute("value", token); form.appendChild(input); }); });</script></label>';
+                                        } elseif(akina_option('verification_type') == 'mCAPTCHA'){
+                                        $robot_comments = '<style>.widget__mcaptcha-brand-name { color:83d6ff} #mcaptcha__widget-container {height: 80px; width: 80%; background-color: #F9F9F9; border-radius: 5px; box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);} @media (prefers-color-scheme: dark) {#mcaptcha__widget-container {height: 80px; width: 80%; background-color: #505050; border-radius: 5px; box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);}} @media (prefers-color-scheme: light) {#mcaptcha__widget-container {height: 80px; width: 80%; background-color: #F9F9F9; border-radius: 5px; box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);}}</style><label class="siren-checkbox-label"><div id="mcaptcha__widget-container"></div><script charset="utf-8">let config = {widgetLink: new URL("'.akina_option('site_key').'"),};new mcaptchaGlue.default(config);</script></label>';
+                                        } else {
+                                        $robot_comments = '<label class="siren-checkbox-label"><input class="siren-checkbox-radio" type="checkbox" name="no-robot"><span class="siren-no-robot-checkbox siren-checkbox-radioInput"></span>'.__('I\'m not a robot', 'sakura').'</label>';
+                                        }	
 					$private_ms = akina_option('open_private_message') ? '<label class="siren-checkbox-label"><input class="siren-checkbox-radio" type="checkbox" name="is-private"><span class="siren-is-private-checkbox siren-checkbox-radioInput"></span>'.__('Comment in private', 'sakura').'</label>' : '';
 					$mail_notify = akina_option('mail_notify') ? '<label class="siren-checkbox-label"><input class="siren-checkbox-radio" type="checkbox" name="mail-notify"><span class="siren-mail-notify-checkbox siren-checkbox-radioInput"></span>'.__('Comment reply notify', 'sakura').'</label>' : '';
 					$args = array(

--- a/footer.php
+++ b/footer.php
@@ -132,12 +132,6 @@
             </li><!--Night-->
         </ul>
     </div>
-    <div class="font-family-controls row-container">
-        <button type="button" class="control-btn-serif selected" data-mode="serif" 
-                onclick="mashiro_global.font_control.change_font()">Serif</button>
-        <button type="button" class="control-btn-sans-serif" data-mode="sans-serif" 
-                onclick="mashiro_global.font_control.change_font()">Sans Serif</button>
-    </div>
 </div>
 <canvas id="night-mode-cover"></canvas>
 <?php if (akina_option('sakura_widget')) : ?>

--- a/footer.php
+++ b/footer.php
@@ -159,6 +159,7 @@
         data-theme="orange">
     </div>
 <?php endif; ?>
+<?php if (!empty(akina_option('notice_infocard'))) { include get_template_directory() . '/user/infocard.php';}?>
 <?php if (akina_option('verification_type') == 'Google reCAPTCHA'&& akina_option('rehidden') == '1') {?>
 	<!--拦截表单提交并验证，验证后自动提交-->
 <script>

--- a/footer.php
+++ b/footer.php
@@ -159,5 +159,32 @@
         data-theme="orange">
     </div>
 <?php endif; ?>
+<?php if (akina_option('verification_type') == 'Google reCAPTCHA'&& akina_option('rehidden') == '1') {?>
+	<!--拦截表单提交并验证，验证后自动提交-->
+<script>
+$('#commentform').on('submit', function(e) {
+  if (!$(this).data('form-submitted')) { // Check if the form was already submitted
+    e.preventDefault();
+    grecaptcha.execute();
+  }
+});
+
+function onRecaptchaSubmit(token) {
+  // Add the token to the form
+  var form = $('#commentform');
+  var input = $('<input>').attr('type', 'hidden').attr('name', 'g-recaptcha-response').val(token);
+  form.append(input);
+
+  // Now submit the form via AJAX
+  form.data('form-submitted', true); // Mark the form as submitted
+  form.trigger('submit'); // Trigger the form submit event
+}
+
+// Automatically execute reCAPTCHA when the page loads
+$(document).ready(function() {
+  grecaptcha.execute();
+});
+</script>
+<?php }?>
 </body>
 </html>

--- a/header.php
+++ b/header.php
@@ -35,6 +35,11 @@ bloginfo( 'name' );$site_description = get_bloginfo( 'description', 'display' );
 if ( $site_description && ( is_home() || is_front_page() ) ) echo " - $site_description";if ( $paged >= 2 || $page >= 2 ) echo ' - ' . sprintf( __( 'page %s ','sakura'), max( $paged, $page ) );/*第 %s 页*/?>
 </title>
 <?php
+//CAPTCHA
+if (akina_option('verification_type') == 'CF Turnstile') { ?><!--CloudFalre验证码--><script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async></script> <?php }elseif(akina_option('verification_type')=='Google reCAPTCHA'){?><!-- Google验证码--> <!-- Google验证码--><script src="https://www.recaptcha.net/recaptcha/api.js" async defer></script><?php }elseif(akina_option('verification_type')=='Google reCAPTCHA v3'){?><script src="https://www.recaptcha.net/recaptcha/api.js?render=<?php echo akina_option('site_key'); ?>"></script><?php }elseif(akina_option('verification_type')=='mCAPTCHA'){?>
+<!--mCAPTCHA--><script src="https://cdn.jsdelivr.net/npm/@mcaptcha/vanilla-glue@0.1.0-alpha-2/dist/index.js"></script>
+<?php }?>
+<?php
 if (akina_option('akina_meta') == true) {
 	$keywords = '';
 	$description = '';

--- a/inc/classes/QQ.php
+++ b/inc/classes/QQ.php
@@ -5,7 +5,7 @@ namespace Sakura\API;
 class QQ
 {
     public static function get_qq_info($qq) {
-        $get_info = file_get_contents('http://r.qzone.qq.com/fcg-bin/cgi_get_portrait.fcg?get_nick=1&uins=' . $qq);
+        $get_info = file_get_contents('http://users.qzone.qq.com/fcg-bin/cgi_get_portrait.fcg?uins=' . $qq);
         $get_info = mb_convert_encoding($get_info, "UTF-8", "GBK");
         $name = json_decode(substr($get_info, 17, -1), true);
         if ($name) {

--- a/inc/theme_plus.php
+++ b/inc/theme_plus.php
@@ -192,7 +192,7 @@ function siren_robot_comment(){
       $recaptchaResponse = $_POST['g-recaptcha-response'];
       $response = file_get_contents("https://www.recaptcha.net/recaptcha/api/siteverify?secret=".akina_option('site_key')."&response=".$recaptchaResponse);
       $response = json_decode($response);
-      if ($response->success == false || $response->score < 0.2) {
+      if ($response->success == false || $response->score < akina_option('rescore')) {
         // reCAPTCHA验证失败
         siren_ajax_comment_err('reCAPTCHA验证失败。<br>reCAPTCHA verification failed.');
       }

--- a/inc/theme_plus.php
+++ b/inc/theme_plus.php
@@ -137,12 +137,137 @@ if(!function_exists('siren_ajax_comment_err')) {
         exit;
     }
 }
+
+//验证码开始
+if (akina_option('verification_type') == 'CF Turnstile') {
 // 机器评论验证
 function siren_robot_comment(){
-  if ( !$_POST['no-robot'] && !is_user_logged_in()) {
-     siren_ajax_comment_err('上车请刷卡。<br>Please comfirm you are not a robot.');
+    $postdata = $_POST['cf-turnstile-response'];
+    // 添加 Secret Key
+    $secret = akina_option('secret_key'); 
+    $headers = array(
+        'body' => [
+            'secret' => $secret,
+            'response' => $postdata
+        ]
+    );
+    $verify = wp_remote_post('https://challenges.cloudflare.com/turnstile/v0/siteverify', $headers);
+    $verify = wp_remote_retrieve_body($verify);
+    $response = json_decode($verify);
+    if ($response->success) {
+        $results['success'] = $response->success;
+    } else {
+        $results['success'] = false;
+    }
+    if (empty($postdata)) {
+        siren_ajax_comment_err('上车请刷卡。<br>Please click the challenge checkbox.');
+    } elseif (!$results['success']) {
+        siren_ajax_comment_err('上车请刷卡。<br>Sorry, spam detected!');
+    }
+}
+if(akina_option('norobot')) add_action('pre_comment_on_post', 'siren_robot_comment');
+}elseif (akina_option('verification_type')=='Google reCAPTCHA') {
+
+function siren_robot_comment(){
+  if (!is_user_logged_in()) {
+    if (isset($_POST['g-recaptcha-response'])) {
+      $recaptchaResponse = $_POST['g-recaptcha-response'];
+      $response = file_get_contents("https://www.recaptcha.net/recaptcha/api/siteverify?secret=".akina_option('site_key')."&response=".$recaptchaResponse);
+      $response = json_decode($response);
+      if ($response->success == false) {
+        // reCAPTCHA验证失败
+        siren_ajax_comment_err('reCAPTCHA验证失败。<br>reCAPTCHA verification failed.');
+      }
+    } else {
+      siren_ajax_comment_err('上车请刷卡。<br>Please comfirm you are not a robot.');
+    }
   }
 }
+    
+}elseif(akina_option('verification_type')=='Google reCAPTCHA v3'){
+    
+function siren_robot_comment(){
+  if (!is_user_logged_in()) {
+    if (isset($_POST['g-recaptcha-response']) && !empty($_POST['g-recaptcha-response'])) {
+      $recaptchaResponse = $_POST['g-recaptcha-response'];
+      $response = file_get_contents("https://www.recaptcha.net/recaptcha/api/siteverify?secret=".akina_option('site_key')."&response=".$recaptchaResponse);
+      $response = json_decode($response);
+      if ($response->success == false || $response->score < 0.2) {
+        // reCAPTCHA验证失败
+        siren_ajax_comment_err('reCAPTCHA验证失败。<br>reCAPTCHA verification failed.');
+      }
+    } else {
+      // 如果没有收到 reCAPTCHA token 或者 token 为空，返回错误消息
+      siren_ajax_comment_err('reCAPTCHA token为空。<br>reCAPTCHA token is empty.');
+    }
+  }
+}
+   
+    
+    
+}
+elseif(akina_option('verification_type')=='mCAPTCHA'){
+    //start
+function siren_robot_comment(){
+  if (!is_user_logged_in()) {
+    if ( !isset($_POST['mcaptcha__token']) || empty($_POST['mcaptcha__token'])) {
+      siren_ajax_comment_err('上车请刷卡。<br>Please comfirm you are not a robot.');
+    } else {
+      $mcaptcha_token = $_POST['mcaptcha__token'];
+      $mcaptcha_sitekey = akina_option('site_key'); 
+      $mcaptcha_account_secret = akina_option('secret_key'); 
+      $verify_url = akina_option('mcaptcha_server'); //
+      $payload = array(
+        'token' => $mcaptcha_token,
+        'key' => $mcaptcha_sitekey,
+        'secret' => $mcaptcha_account_secret,
+      );
+      $payload = json_encode($payload);
+   //wp_remote_post 请求被拒绝，换CURL
+      // 初始化cURL会话
+      $ch = curl_init($verify_url);
+
+      // 设置cURL选项
+      curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+      curl_setopt($ch, CURLOPT_POST, true);
+      curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
+      curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/json'));
+
+      // 发送请求并获取响应
+      $response = curl_exec($ch);
+
+      // 关闭cURL会话
+      curl_close($ch);
+
+      if ($response === false) {
+        siren_ajax_comment_err('CAPTCAH请求失败 <br>A Error by mCAPTCHA');
+      } else {
+        $data = json_decode($response);
+        if ($data->valid==false) {
+          // mCAPTCHA验证失败
+          siren_ajax_comment_err('上车请刷卡。<br>Please comfirm you are not a robot.');
+        }
+      }
+    }
+  }
+}
+
+
+
+
+//end
+    
+}else{
+    // 机器评论验证
+  function siren_robot_comment(){
+    if ( !$_POST['no-robot'] && !is_user_logged_in()) {
+       siren_ajax_comment_err('上车请刷卡。<br>Please comfirm you are not a robot.');
+    }
+  }  
+  }
+  
+  /*结束*/
+
 if(akina_option('norobot')) add_action('pre_comment_on_post', 'siren_robot_comment');
 // 纯英文评论拦截
 function scp_comment_post( $incoming_comment ) {

--- a/options.php
+++ b/options.php
@@ -884,6 +884,20 @@ $options[] = array(
     'std' => 'https://demo.mcaptcha.org/api/v1/pow/siteverify',
     'type' => 'text'
 );
+$options[] = array(
+    'name' => __('reCAPTCHA 隐形模式', 'sakura'), /*机器人验证*/
+    'desc' => __('选择开启隐形模式，需要在reCAPTCHA控制台设置类型：v2 隐形 Enterprise', 'sakura'), /*开启机器人验证*/
+    'id' => 'rehidden',
+    'std' => '0',
+    'type' => 'checkbox'
+    );
+$options[] = array(
+    'name' => '验证分数',
+    'desc' => 'reCAPTCHAv3的验证分数，从0.0-1.0，越高越接近人类。',
+    'id' => 'rescore',
+    'std' => '0.5',
+    'type' => 'text'
+);    
 
     $options[] = array(
         'name' => __('QQ avatar link encryption', 'sakura'), /*QQ头像链接加密*/

--- a/options.php
+++ b/options.php
@@ -1190,6 +1190,13 @@ $options[] = array(
         'id' => 'notice_title',
         'std' => '',
         'type' => 'text');
+    //信息卡
+    $options[] = array(
+        'name' => __('信息卡', 'sakura'),
+        'desc' => __('在右下角弹出一个信息卡，可以用于发布公告通知，移动端为底部居中^_^', 'sakura'), 
+        'id' => 'notice_infocard',
+        'std' => '',
+        'type' => 'text');
     $options[] = array(
         'name' => __('Bilibili UID', 'sakura'), /*bilibiliUID*/
         'desc' => __('Fill in your UID, eg.https://space.bilibili.com/13972644/, only fill in with the number part.', 'sakura'),

--- a/options.php
+++ b/options.php
@@ -847,6 +847,45 @@ function optionsframework_options()
         'type' => 'checkbox');
 
     $options[] = array(
+    'name' => __('机器人验证方式', 'sakura'), /* 验证类型 */
+    'desc' => __('reCAPTCHA已更换为reCAPTCHA.net，国内正常使用。', 'sakura'), /* 选择验证码类型 */
+    'id' => 'verification_type',
+    'std' => '0',
+    'type' => 'radio',
+    'options' => array(
+        'CF Turnstile' => __('Cloudflare Turnstile 网络波动可能导致验证失败，需要设置站点密钥与后端秘钥。', 'sakura'),
+        'Google reCAPTCHA' => __('Google reCAPTCHA，需要设置站点密钥与后端秘钥。', 'sakura'),
+        'Google reCAPTCHA v3' => __('Google reCAPTCHA v3，需要设置站点密钥与后端秘钥。', 'sakura'),
+      //'geetest' => __('geetest，需要设置密钥', 'sakura'),
+        'mCAPTCHA' => __('mCAPTCHA，需要自己使用Docker搭建，并配置站点密钥与后端密钥', 'sakura'),
+        'Theme CAPTCHA' => __('主题内建简单验证', 'sakura'),
+    )
+);
+
+$options[] = array(
+    'name' => '站点密钥',
+    'desc' => '设置前端的站点密钥/Site-key，如果使用mCAPTCHA则填写完整小部件链接',
+    'id' => 'site_key',
+    'std' => '',
+    'type' => 'text'
+);
+
+$options[] = array(
+    'name' => '后端密钥',
+    'desc' => '设置与验证服务器请求的密钥/Secret-key',
+    'id' => 'secret_key',
+    'std' => '',
+    'type' => 'text'
+);
+$options[] = array(
+    'name' => 'mCAPTCHA服务器地址',
+    'desc' => '没有选择可以不填',
+    'id' => 'mcaptcha_server',
+    'std' => 'https://demo.mcaptcha.org/api/v1/pow/siteverify',
+    'type' => 'text'
+);
+
+    $options[] = array(
         'name' => __('QQ avatar link encryption', 'sakura'), /*QQ头像链接加密*/
         'desc' => __('Do not display the user\'s qq avatar links directly.', 'sakura'), /*不直接暴露用户qq头像链接*/
         'id' => 'qq_avatar_link',

--- a/user/infocard.php
+++ b/user/infocard.php
@@ -1,0 +1,33 @@
+<style>
+			.smt-app{position:relative}.smt-app .sm-fixed{z-index:10000000 !important;position:fixed}.smt-app .sm-fixed-2{z-index:11000000 !important}.smt-app,.smt-app *{letter-spacing:normal;font-size:14px;line-height:normal;font-weight:normal;margin:0}.smt-app img{user-select:none}.smt-app .sm-shadow{box-shadow:rgba(0,0,0,0.1) 0px 4px 12px}.smt-wrapper{background:none;padding:0;width:auto;height:auto}.hover-opacity{cursor:pointer;transition:opacity 200ms linear}.hover-opacity:hover{opacity:0.95 !important}.powered-link{font-size:14px !important;color:#555;text-decoration:none;margin-top:5px;display:inline-block;white-space:nowrap}.powered-link img{width:14px !important;height:14px !important}.icon-wrapper+.powered-link{position:absolute;left:50%;transform:translateX(-55%) !important}.sm-disable-animation{animation-duration:0ms !important}.sm-close{padding:0;line-height:normal;position:absolute;color:#fff;top:12px;right:12px;width:24px;height:24px;font-size:22px;cursor:pointer;text-align:center;z-index:1;font-style:normal;outline:none;border:none;box-shadow:none}.material-icons{font-family:'Material Icons' !important}
+			.smt-wrapper.top-left{left:30px;top:25px}.smt-wrapper.top-right{top:25px;right:30px}.smt-wrapper.bottom-left{bottom:25px;left:30px}.smt-wrapper.bottom-right{bottom:25px;right:30px}.smt-wrapper.bottom,.smt-wrapper.top,.smt-wrapper.bottom-center,.smt-wrapper.top-center{left:50%;transform:translateX(-50%);right:initial}.smt-wrapper.bottom,.smt-wrapper.bottom-center{bottom:25px !important}.smt-wrapper.top,.smt-wrapper.top-center{top:25px !important}.smt-wrapper.left,.smt-wrapper.right{top:50%;transform:translateY(-50%)}.smt-wrapper.left{left:30px}.smt-wrapper.right{right:30px}.smt-app .icon-wrapper{box-sizing:border-box;height:60px;width:60px;padding:0;border-radius:50%;box-shadow:5px 0px 10px rgba(0,0,0,0.5);cursor:pointer;transition:opacity 300ms linear;display:block}.smt-app .icon-wrapper img{height:100% !important;width:100% !important;display:inline !important;min-height:auto !important}
+			.smt-app-flash_cards .smt-wrapper{width:auto !important;height:auto !important}.smt-app-flash_cards .flash-cards-block{position:relative;color:black;font-size:14px;background:white;border-radius:3px;max-width:400px;min-width:50px;padding:20px 15px;white-space:nowrap;text-overflow:ellipsis;overflow:hidden;border:1px solid #ccc;box-shadow:0 3px 7px rgba(0,0,0,0.12);width:330px}.smt-app-flash_cards .flash-cards-block:not(.show){display:none}.smt-app-flash_cards .flash-cards-block.show{animation:puff-in-center 0.5s cubic-bezier(0.47, 0, 0.745, 0.715) both}.smt-app-flash_cards .flash-cards-block .flash-cards-header{display:flex;justify-content:space-between;flex:1 1 auto}.smt-app-flash_cards .flash-cards-block .flash-cards-header .flash-cards-title{flex:1 1 auto;font-size:16px;font-weight:700;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.smt-app-flash_cards .flash-cards-block .flash-cards-header .flash-cards-close{flex:0 0 auto}.smt-app-flash_cards .flash-cards-block .flash-cards-message{line-height:1.5;color:#444;font-size:14px;font-weight:400;font-family:Montserrat, sans-serif;white-space:normal !important}.smt-app-flash_cards .flash-cards-block .flash-cards-button{margin-top:1em;border-radius:3px !important;border:1px solid !important;box-shadow:none !important;text-decoration:none !important;font-size:1.2em !important;padding:5px 0 !important;width:100%;display:block;text-align:center;cursor:pointer;transition:color, background-color 400ms linear}.smt-app-flash_cards .flash-cards-block .flash-cards-button:not(:hover){background-color:#fff !important}.smt-app-flash_cards .flash-cards-block .flash-cards-button:hover{border-color:white !important;color:white !important}.smt-app-flash_cards .powered-link{text-decoration:underline !important;display:block;text-align:center;margin-bottom:-10px;margin-top:10px;color:#540bfa;font-size:10px}@keyframes puff-in-center{0%{-webkit-transform:scale(2);transform:scale(2);-webkit-filter:blur(4px);filter:blur(4px);opacity:0}100%{-webkit-transform:scale(1);transform:scale(1);-webkit-filter:blur(0px);filter:blur(0px);opacity:1}}@keyframes puff-out-center{0%{transform:scale(1);filter:blur(0px);opacity:1}100%{transform:scale(2);filter:blur(4px);opacity:0}}
+		</style>
+		
+		<div class="smt-app smt-app-flash_cards force-mobile">
+			<div class="smt-wrapper sm-fixed bottom-right" style="z-index: 2147483647;">
+
+				<div class="flash-cards-block show">
+
+					<div class="flash-cards-header">
+						<div class="flash-cards-title">INFO</div>
+						<div class="flash-cards-close hover-opacity" onclick="javascript:document.querySelector('.smt-app-flash_cards').remove()">
+							<style>
+								.smt-flash_cards-clear-svg .path-main {fill: #777 !important;} .smt-flash_cards-clear-svg .path-addition {fill: none !important;}
+							</style>
+							<svg class="smt-flash_cards-clear-svg" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+								<path fill="#777" class="path-main" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
+								<path d="M0 0h24v24H0z" class="path-addition" fill="none" ></path>
+							</svg>
+						</div>
+					</div>
+
+					<div class="flash-cards-message"><?php echo akina_option('notice_infocard');?></div>
+
+					<a style="color: <?php echo akina_option('theme_skin');?>; border-color: <?php echo akina_option('theme_skin');?>; background-color: <?php echo akina_option('theme_skin');?>" class="flash-cards-button" onclick="javascript:document.querySelector('.smt-app-flash_cards').remove()">
+						Get it!
+					</a>
+				</div>
+
+			</div>
+		</div>


### PR DESCRIPTION
My website has received dozens of malicious comments, nearly 100 meaningless comments. The simple human verification of the theme is not real verification, so I added 4 common types of CAPTCHA and ensured that their style and functionality are compatible with the theme. QQ has updated its api, the old api cannot retrieve information, the updated api can retrieve avatars but cannot properly retrieve nicknames. Chinese nicknames will decode incorrectly, I have tried common encoding formats to no avail, and need others to find the correct encoding format.
![cloudflare](https://github.com/mashirozx/sakura/assets/47671569/51698e8a-eb52-4c0d-8124-0b9d9c41fb5b)
![reCAPTCHAV2](https://github.com/mashirozx/sakura/assets/47671569/c129b28e-6cc1-47d3-ba44-80f2c25c009e)
![reCAPTCHAV3](https://github.com/mashirozx/sakura/assets/47671569/3fd7bb61-5da5-4ba2-9e07-ab27f8c0139f)
![mCAPTCHA](https://github.com/mashirozx/sakura/assets/47671569/5d31472d-5fb2-4940-8d4d-5f072354661b)

